### PR TITLE
fix: onChange event not trigger when shift key combination input

### DIFF
--- a/vendor/ueditor/ueditor.all.js
+++ b/vendor/ueditor/ueditor.all.js
@@ -14417,7 +14417,7 @@ UE.plugins['undo'] = function () {
 
         var me = this;
         var keyCode = evt.keyCode || evt.which;
-        if (!keys[keyCode] && !evt.ctrlKey && !evt.metaKey && !evt.shiftKey && !evt.altKey) {
+        if (!keys[keyCode] && !evt.ctrlKey && !evt.metaKey && !evt.shiftKey && !evt.altKey || (evt.shiftKey && /\w/.test(evt.key))) {
             if (inputType)
                 return;
 


### PR DESCRIPTION
Like "shift" + "A" input, now the editor can't recognize and abort onChange event